### PR TITLE
린트 규칙 추가

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -10,7 +10,26 @@
         "ter-func-call-spacing": [true, "never"],
         "space-before-function-paren": [true, "always"],
         "arrow-parens": false,
+        "indent": [true, "spaces", 2],
         "object-curly-spacing": [true, "always"],
+        "brace-style": [
+            true,
+            "stroustrup",
+            {
+                "allowSingleLine": false
+            }
+        ],
+        "ter-indent": [
+            true,
+            2,
+            {
+                "ObjectExpression": 1,
+                "ArrayExpression": 1,
+                "CallExpression": {
+                    "arguments": 1
+                }
+            }
+        ],
         "semicolon": [true, "never"]
     },
     "rulesDirectory": []


### PR DESCRIPTION
이 풀리퀘스트로 바뀌는 점:   
- 2 스페이스 인덴트를 사용
- 중괄호는 스트로스트롭을 따름
- 함수호출 소괄호, 중괄호, 대괄호 내용 인덴트는 2스페이스

@kswgit
