### PR TITLE
게시글, 댓글 및 좋아요 수 작동하게 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 yarn-error.log
 db
 .idea
+db/test.sql

--- a/src/controllers/cia.ts
+++ b/src/controllers/cia.ts
@@ -32,7 +32,7 @@ export const Patch = async (ctx, next) => {
     const cia: Cia = await conn
     .getRepository(Cia)
     .createQueryBuilder("cia")
-    .where("cia.name = :name", { name : ctx.params.name })
+    .where("cia.title = :title", { title: ctx.params.title })
     .getOne()
 
     /* 입력받은 값으로 수정 */

--- a/src/controllers/comments.ts
+++ b/src/controllers/comments.ts
@@ -150,12 +150,12 @@ export const PostLikes = async (ctx, next) => {
     /* 세션 유저 불러오기 */
     const user: Users = ctx.session.user
 
+    /* 세션 유저의 댓글 좋아요 수 1 증가 */
+    ++(user.numberOfCommentLikes)
+
     /* 세션의 유저와 좋아요 relation 설정 */
     comment.likedBy.push(user)
     await conn.manager.save(comment)
-
-    /* 세션 유저의 댓글 좋아요 수 1 증가 */
-    ++(user.numberOfCommentLikes)
     await conn.manager.save(user)
   }
   catch (e) {

--- a/src/controllers/documents.ts
+++ b/src/controllers/documents.ts
@@ -119,12 +119,11 @@ export const PostLikes = async (ctx, next) => {
     /* 세션 유저 불러오기 */
     const user: Users = ctx.session.user
 
+    /* 게시글에 좋아요한 수 1 증가 */
+    ++(user.numberOfDocumentLikes)
+
     /* 게시글과 유저의 좋아요 relation 설정 */
     document.likedBy.push(user)
-
-    /* 게시글에 좋아요한 수 1 증가 */
-    ++(user.numberOfCommentLikes)
-
     await conn.manager.save(user)
     await conn.manager.save(document)
   }
@@ -157,7 +156,7 @@ export const DeleteLikes = async (ctx, next) => {
     .remove(user)
 
     /* 게시글에 좋아요한 수 1 감소 */
-    --(user.numberOfCommentLikes)
+    --(user.numberOfDocumentLikes)
     await conn.manager.save(user)
   }
   catch (e) {

--- a/src/controllers/files.ts
+++ b/src/controllers/files.ts
@@ -1,5 +1,6 @@
 import { Connection, getConnection, getManager } from "typeorm"
 import Files from "../entities/files"
+import Users from "../entities/users"
 
 /* 모든 파일 GET */
 export const Get = async (ctx, next) => {
@@ -27,6 +28,8 @@ export const Post = async (ctx, next) => {
   file.savedPath = "YO"
 
   try{
+    const user: Users = ctx.params.user
+    file.user = user
     await conn.manager.save(file)
   }
   catch (e){

--- a/src/route.ts
+++ b/src/route.ts
@@ -34,7 +34,6 @@ export const router = new Router()
   출처 : https://developer.mozilla.org/ko/docs/Web/HTTP/Status
 */
 
-// params를 전달하면 post대신 put사용
 router.post("/login", Sessions.Login)
 router.post("/logout", Sessions.Logout)
 
@@ -68,4 +67,4 @@ router.post("/files", Files.Post)
 router.delete("/files/:id", Files.Delete)
 
 router.post("/cia", Cia.Post)
-router.patch("/cia/:name", Cia.Patch)
+router.patch("/cia/:title", Cia.Patch)


### PR DESCRIPTION
이 풀리퀘스트로 바뀌는 점:   
- 게시글과 댓글의 수가 정상적으로 증감합니다.
- 게시글과 댓글의 좋아요 수가 정상적으로 증감합니다.
- .gitignore에 test.sql이 추가됩니다. (bugfix)
- cia 엔티티의 변수 이름이 변경되어 관련 내역이 수정됩니다.
- 이제 파일 생성 시 세션의 유저 데이터를 받아옵니다.

@RomuRaymu 
