### PR TITLE
프론트엔드 요청 - 중복 아이디에 해당하는 에러 메시지 리턴

### DIFF
--- a/src/controllers/users.ts
+++ b/src/controllers/users.ts
@@ -73,6 +73,9 @@ export const Post = async (ctx, next) => {
     await conn.manager.save(user)
   }
   catch (e) {
+    if (e.message === "SQLITE_CONSTRAINT: UNIQUE constraint failed: users.username"){
+      ctx.throw(403, "중복 아이디입니다.")
+    }
     ctx.throw(400, e)
   }
 


### PR DESCRIPTION
이 풀리퀘스트로 바뀌는 점:   
- 아이디 중복에는 403 Forbidden 에러 메시지를 반환합니다.

@sGOM 
