### PR TITLE
프론트엔드에 알맞게 데이터 보내기

### DIFF
--- a/src/controllers/comments.ts
+++ b/src/controllers/comments.ts
@@ -68,8 +68,8 @@ export const Post = async (ctx, next) => {
 
     /* 댓글 작성자의 댓글 수 1 증가 */
     ++(comment.author.nComments)
-    await conn.manager.save(comment.author)
 
+    await conn.manager.save(comment.author)
     await conn.manager.save(comment)
   }
   catch (e){

--- a/src/controllers/comments.ts
+++ b/src/controllers/comments.ts
@@ -154,13 +154,16 @@ export const PostLikes = async (ctx, next) => {
     /* 세션 유저 불러오기 */
     const user: Users = ctx.session.user
 
-    /* 세션 유저의 댓글 좋아요 수 1 증가 */
-    ++(user.nCommentLikes)
-
     /* 세션의 유저와 좋아요 relation 설정 */
     comment.likedBy.push(user)
+    ++(user.nCommentLikes)
+
     await conn.manager.save(comment)
     await conn.manager.save(user)
+
+    /* POST 성공 응답 */
+    ctx.body = comment.likedBy
+    ctx.response.status = 200
   }
   catch (e) {
     if (e.message ===
@@ -169,9 +172,6 @@ export const PostLikes = async (ctx, next) => {
     }
     ctx.throw(400, e)
   }
-
-  /* POST 성공 응답 */
-  ctx.response.status = 200
 }
 
 /* 해당 댓글 좋아요 DELETE */

--- a/src/controllers/documents.ts
+++ b/src/controllers/documents.ts
@@ -158,13 +158,16 @@ export const PostLikes = async (ctx, next) => {
     /* 세션 유저 불러오기 */
     const user: Users = ctx.session.user
 
-    /* 게시글에 좋아요한 수 1 증가 */
-    ++(user.nDocumentLikes)
-
     /* 게시글과 유저의 좋아요 relation 설정 */
     document.likedBy.push(user)
+    ++(user.nDocumentLikes)
+
     await conn.manager.save(user)
     await conn.manager.save(document)
+
+    /* POST 완료 응답 */
+    ctx.body = document.likedBy
+    ctx.response.status = 200
   }
   catch (e) {
     if (e.message ===
@@ -173,9 +176,6 @@ export const PostLikes = async (ctx, next) => {
     }
     ctx.throw(400, e)
   }
-
-  /* POST 완료 응답 */
-  ctx.response.status = 200
 }
 
 /* 해당 게시글 좋아요 DELETE */

--- a/src/controllers/documents.ts
+++ b/src/controllers/documents.ts
@@ -69,12 +69,14 @@ export const Post = async (ctx, next) => {
   const document: Documents = new Documents()
   const data = ctx.request.body
 
-  document.text = data.text
   try {
     document.author = ctx.session.user
+    document.text = data.text
 
     /* 게시글 작성자의 게시글 수 1 증가 */
     ++(document.author.nDocuments)
+
+    await conn.manager.save(document.author)
     await conn.manager.save(document)
   }
   catch (e) {

--- a/src/controllers/documents.ts
+++ b/src/controllers/documents.ts
@@ -8,7 +8,7 @@ export const GetOne = async (ctx, next) => {
   const conn: Connection = getConnection()
 
   try{
-    const document = await conn
+    const document: Documents = await conn
     .getRepository(Documents)
     .findOne(ctx.params.id, {
       relations: [
@@ -36,7 +36,7 @@ export const GetTimeline = async (ctx, next) => {
   const conn: Connection = getConnection()
 
   try{
-    const timeline = await conn
+    const timeline: Documents[] = await conn
     .getRepository(Documents)
     .find({
       relations: [
@@ -48,6 +48,10 @@ export const GetTimeline = async (ctx, next) => {
         "comments.replies",
         "likedBy",
       ]})
+
+    timeline.sort((lhs: Documents, rhs: Documents) => {
+      return rhs.createdAt.getTime() - lhs.createdAt.getTime()
+    })
 
     ctx.body = timeline
   }

--- a/src/controllers/users.ts
+++ b/src/controllers/users.ts
@@ -94,6 +94,7 @@ export const Post = async (ctx, next) => {
     await conn.manager.save(user)
   }
   catch (e) {
+    await conn.manager.remove(user)
     if (e.message ===
       "SQLITE_CONSTRAINT: UNIQUE constraint failed: users.username"){
       ctx.throw(409, e)

--- a/src/entities/users.ts
+++ b/src/entities/users.ts
@@ -120,7 +120,7 @@ export default class Users {
   @Column("int", {
     default: 0,
   })
-  public nDocuments:	number
+  public nDocuments: number
 
   /* 댓글 수 */
   @Column("int", {


### PR DESCRIPTION
이 풀리퀘스트로 바뀌는 점:   
- 상수 선언부에 타입을 표시했습니다.
- 타임라인을 최신글 순으로 불러옵니다.
- 작성글이 제대로 증가하지 않는 문제를 수정했습니다.
- 유저 POST 실패 시, DB에 유저 정보를 저장하지 않고 삭제합니다.
- 좋아요 POST의 응답으로 변경된 결과를 표시합니다.
- 기타 코드 수정

@kswgit @sGOM 
