### PR TITLE
데이터베이스 스키마 추가 및 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ node_modules
 yarn-error.log
 .idea
 db/
-*.sql

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -13,7 +13,7 @@ export async function Authenticate (username: string, password: string): Promise
       relations: ['profileImage']
     })
   const user = users[0]
-  const derivedKey = crypto.pbkdf2Sync(user.password, user.salt, 131071, 64, 'sha512')
+  const derivedKey = crypto.pbkdf2Sync(password, user.salt, 131071, 64, 'sha512')
 
   if (derivedKey.toString('hex') !== user.password)
     throw new Error('password mismatch')

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -13,11 +13,9 @@ export async function Authenticate (username: string, password: string): Promise
       relations: ['profileImage']
     })
   const user = users[0]
+  const derivedKey = crypto.pbkdf2Sync(user.password, user.salt, 131071, 64, 'sha512')
 
-  const [encryptedKey, salt] = user.password.split("@")
-  const derivedKey = crypto.pbkdf2Sync(password, salt, 131071, 64, 'sha512')
-
-  if (derivedKey.toString('hex') !== encryptedKey)
+  if (derivedKey.toString('hex') !== user.password)
     throw new Error('password mismatch')
   return user
 }

--- a/src/controllers/cia.ts
+++ b/src/controllers/cia.ts
@@ -1,0 +1,101 @@
+import { Connection, getConnection } from "typeorm"
+import Cia from "../entities/cia"
+
+/* 해당 동아리 정보 GET */
+export const GetOne = async (ctx, next) => {
+  const conn: Connection = getConnection()
+
+  try{
+    const cia: Cia = await conn
+    .getRepository(Cia)
+    .createQueryBuilder()
+    .where("cia.title = :title", { title: ctx.params.title })
+    .getOne()
+
+    ctx.body = cia
+  }
+  catch (e){
+    ctx.throw(400, e)
+  }
+
+  /* GET 완료 응답 */
+  ctx.response.status = 200
+}
+
+/* 모든 동아리 정보 GET - title만 로드 */
+export const GetAll = async (ctx, next) => {
+  const conn: Connection = getConnection()
+  const responseBody: string[] = []
+
+  try{
+    const allCia: Cia[] = await conn
+    .getRepository(Cia)
+    .find()
+
+    /* 모든 게시물의 title만 ctx.body에 반환 */
+    for (const ciaSet of allCia.entries()) {
+      const cia: Cia = ciaSet["1"]
+      responseBody.push(cia.title)
+    }
+  }
+  catch (e){
+    ctx.throw(400, e)
+  }
+
+  /* GET 완료 응답 */
+  ctx.body = responseBody
+  ctx.response.status = 200
+}
+
+/* 동아리 정보 POST */
+export const Post = async (ctx, next) => {
+  const conn: Connection = getConnection()
+  const cia: Cia = new Cia()
+  const data = ctx.request.body
+
+  cia.title = data.title
+  cia.content = data.content
+
+  try{
+    await conn.manager.save(cia)
+  }
+  catch (e){
+    ctx.throw(400, e)
+  }
+
+  /* POST 완료 응답 */
+  ctx.body = cia
+  ctx.response.status = 200
+}
+
+/* 해당 동아리 정보 PATCH */
+export const PatchOne = async (ctx, next) => {
+  const conn: Connection = getConnection()
+  const data = ctx.request.body
+
+  try{
+    /* name 문서를 찾아서 가져옴 */
+    const cia: Cia = await conn
+    .getRepository(Cia)
+    .createQueryBuilder()
+    .where("cia.title = :title", { title: ctx.params.title })
+    .getOne()
+
+    /* 입력받은 값으로 수정 */
+    if (data.title !== undefined){
+      cia.title = data.title
+    }
+    if (data.text !== undefined){
+      cia.content = data.content
+    }
+
+    await conn.manager.save(cia)
+    ctx.body = cia
+  }
+  catch (e){
+    ctx.throw(400, e)
+  }
+
+  /* PATCH 완료 응답 */
+  ctx.response.status = 200
+}

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -106,7 +106,7 @@ export const Post = async (ctx, next) => {
   /* 프로필 이미지 DB 저장 및 relation 설정 */
   try {
     profile.filename = data.profileImage
-    profile.savedPath = "/images/MIKI.png"
+    profile.savedPath = "/images/profile_image_default.png"
     profile.user = user
 
     await conn.manager.save(profile)

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -88,9 +88,10 @@ export const Post = async (ctx, next) => {
   user.favoriteCharacter = data.favoriteCharacter
 
   const salt: Buffer = crypto.randomBytes(64)
-  const derivedKey: Buffer = crypto.pbkdf2Sync(data.password, salt.toString('hex'), 131071, 64, 'sha512')
-  user.password = derivedKey.toString('hex')
   user.salt = salt.toString('hex')
+
+  const derivedKey: Buffer = crypto.pbkdf2Sync(data.password, user.salt, 131071, 64, 'sha512')
+  user.password = derivedKey.toString('hex')
 
   try {
     /* 데이터 저장 */

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -79,7 +79,7 @@ export const Post = async (ctx, next) => {
   user.nTh = data.nTh
   user.birthdate = data.birthdate
   user.username = data.username
-  user.department = data.department
+  user.major = data.major
   user.studentNumber = data.studentNumber
   user.email = data.email
   user.phoneNumber = data.phoneNumber
@@ -322,7 +322,7 @@ export const PatchOne = async (ctx, next) => {
       user.birthdate = data.birthdate
     }
     if (data.major !== undefined) {
-      user.department = data.major
+      user.major = data.major
     }
     if (data.studentNumber !== undefined) {
       user.studentNumber = data.studentNumber

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -89,7 +89,8 @@ export const Post = async (ctx, next) => {
 
   const salt: Buffer = crypto.randomBytes(64)
   const derivedKey: Buffer = crypto.pbkdf2Sync(data.password, salt.toString('hex'), 131071, 64, 'sha512')
-  user.password = `${derivedKey.toString('hex')}@${salt.toString('hex')}`
+  user.password = derivedKey.toString('hex')
+  user.salt = salt.toString('hex')
 
   try {
     /* 데이터 저장 */

--- a/src/entities/cia.ts
+++ b/src/entities/cia.ts
@@ -1,0 +1,9 @@
+import { Entity } from "typeorm"
+import Content from "./content"
+
+/* 동아리 정보 테이블 스키마 */
+@Entity()
+export default class Cia extends Content {
+  // Content와 동일
+  // key-value(text) 쌍 데이터
+}

--- a/src/entities/user.ts
+++ b/src/entities/user.ts
@@ -76,6 +76,16 @@ export default class User {
 
   // 회원가입 시 입력받는 정보 끝
 
+  /* 프로필 배너 */
+  @OneToOne(type => File, files => files.user)
+  public profileBanner: File
+
+  /* 프로필 텍스트 */
+  @Column("text", {
+    default: "",
+  })
+  public profileText:	string
+
   /* 회원 가입 일자 */
   @CreateDateColumn()
   public joinDate: Date
@@ -86,17 +96,25 @@ export default class User {
   })
   public isApproved: boolean
 
-  /* 프로필 */
-  @Column("text", {
-    default: "",
-  })
-  public profileText:	string
+  /* 프로필 배너 */
 
   /* DB관리 권한 유무 */
   @Column("boolean", {
     default: false,
   })
   public isSuperuser:	boolean
+
+  /* 임원진 여부 */
+  @Column("boolean", {
+    default: false,
+  })
+  public isBoardMemeber:	boolean
+
+  /* 총무 여부 */
+  @Column("boolean", {
+    default: false,
+  })
+  public isManager:	boolean
 
   /* 활동인구 여부 */
   @Column("boolean", {

--- a/src/entities/user.ts
+++ b/src/entities/user.ts
@@ -42,6 +42,10 @@ export default class User {
   @Column("text")
   public password: string
 
+  /* 비밀번호 솔트 */
+  @Column("text")
+  public salt: string
+
   /* 전공 */
   @Column("text")
   public major: string

--- a/src/entities/user.ts
+++ b/src/entities/user.ts
@@ -100,8 +100,6 @@ export default class User {
   })
   public isApproved: boolean
 
-  /* 프로필 배너 */
-
   /* DB관리 권한 유무 */
   @Column("boolean", {
     default: false,

--- a/src/entities/user.ts
+++ b/src/entities/user.ts
@@ -42,9 +42,9 @@ export default class User {
   @Column("text")
   public password: string
 
-  /* 학과 */
+  /* 전공 */
   @Column("text")
-  public department: string
+  public major: string
 
   /* 학번 */
   @Column("int")


### PR DESCRIPTION
Fixes #98, #102 .

이 풀리퀘스트로 바뀌는 점:   
- 유저 스키마에 관리자/임원진/총무/일반 계정 구분을 위한 컬럼, 프로필 배너 컬럼 추가
- 유저 스키마에 전공 컬럼 이름을 major로 변경
- cia 테이블이 다시 추가되어 활동인구 신청 기간, 동아리방 비밀번호 등 정보를 key-value text 쌍으로 관리 가능
- 더 이상 비밀번호 컬럼에 salt 값이 같이 들어가지 않습니다

@droplet92
